### PR TITLE
install dependencies at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:6.3.1
 ADD . /opt/api
 WORKDIR /opt/api
+RUN npm install --production
 CMD ["npm", "start"]


### PR DESCRIPTION
Need to run `npm install` during Docker build.