### PR TITLE
fix(lib): add better error messaging

### DIFF
--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -33,10 +33,12 @@ module.exports = {
   checks to see if an image exists in the catalog. Only returns string values as to whether or not it does exist.
 **/
 function checkImage(req, res, next) {
+    console.log('TESTING')
     if (req.body.catalog || req.path.split('/')[1] === 'catalog') {
         debug('Get: Catalog %s %s', req.params.image, req.params.version);
         let url = `${catalogit}/v1/container/${req.params.image}/${req.params.version}`;
-
+        
+        console.log('TESTING', url)
         request.get(url, null)
             .then(value => {
                 debug('Request to CatalogIt %j', value);

--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -33,12 +33,10 @@ module.exports = {
   checks to see if an image exists in the catalog. Only returns string values as to whether or not it does exist.
 **/
 function checkImage(req, res, next) {
-    console.log('TESTING')
     if (req.body.catalog || req.path.split('/')[1] === 'catalog') {
         debug('Get: Catalog %s %s', req.params.image, req.params.version);
         let url = `${catalogit}/v1/container/${req.params.image}/${req.params.version}`;
         
-        console.log('TESTING', url)
         request.get(url, null)
             .then(value => {
                 debug('Request to CatalogIt %j', value);

--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -36,11 +36,11 @@ function checkImage(req, res, next) {
     if (req.body.catalog || req.path.split('/')[1] === 'catalog') {
         debug('Get: Catalog %s %s', req.params.image, req.params.version);
         let url = `${catalogit}/v1/container/${req.params.image}/${req.params.version}`;
-        
+
         request.get(url, null)
             .then(value => {
                 debug('Request to CatalogIt %j', value);
-                req.customsMessages.push(`Image Exists In Catalog: ${req.params.image} v${req.params.version}`);
+                req.customsMessages.push(`Image Exists In Catalog: ${req.params.image}:${req.params.version}`);
                 next();
             })
             .catch(reason => {

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -17,7 +17,9 @@ module.exports = {
                 passed++;
             }
             else {
-                results.push(`missing field ${field}`);
+                let error = `missing field: '${field}'`;
+                results.push(error);
+                console.log(error);
             }
         });
 

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -17,9 +17,7 @@ module.exports = {
                 passed++;
             }
             else {
-                let error = `missing field: '${field}'`;
-                results.push(error);
-                console.log(error);
+                results.push(`missing field: '${field}'`);
             }
         });
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -10,14 +10,12 @@ module.exports = {
             options.headers = headers || {};
 
             request = http.get(options, response => {
-                if (response.statusCode < 200 || response.statusCode > 299) {
-                    reject(new Error(`Failed to GET ${path} (Status code: ${response.statusCode})`));
-                }
-
                 let result = [];
-                response.on('data', chunk => result.push(chunk));
+                response.on('data', chunk => {
+                  result.push(chunk)
+                });
                 response.on('end', _ => {
-                    sendResponse(result, response, path, resolve, reject);
+                    sendResponse(result, response, path, resolve, reject, 'GET');
                 });
             });
             request.on('error', err => reject(err));
@@ -40,7 +38,7 @@ module.exports = {
                 let result = [];
                 response.on('data', chunk => result.push(chunk));
                 response.on('end', _ => {
-                    sendResponse(result, response, path, resolve, reject);
+                    sendResponse(result, response, path, resolve, reject, 'POST');
                 });
             });
             request.on('error', err => reject(err));
@@ -60,14 +58,10 @@ module.exports = {
             options.headers['Content-Length'] = Buffer.byteLength(body);
 
             request = http.request(options, response => {
-                if (response.statusCode < 200 || response.statusCode > 299) {
-                    reject(new Error(`Failed to PUT ${path} (Status code: ${response.statusCode})`));
-                }
-
                 let result = [];
                 response.on('data', chunk => result.push(chunk));
                 response.on('end', _ => {
-                    sendResponse(result, response, path, resolve, reject);
+                    sendResponse(result, response, path, resolve, reject, 'PUT');
                 });
             });
             request.on('error', err => reject(err));
@@ -80,18 +74,18 @@ module.exports = {
  sendResponse
  commond function used by all methods to finalize a response.
 **/
-function sendResponse(result, response, path, resolve, reject) {
+function sendResponse(result, response, path, resolve, reject, verb) {
       result = result.join('');
       try {
           result = JSON.parse(result);
           if (response.statusCode < 200 || response.statusCode > 299) {
-              reject(new Error(`Failed to POST ${path} (Status code: ${response.statusCode}) (Message: ${JSON.stringify(result)})`));
+              reject(new Error(`Failed to ${verb} ${path} (Status code: ${response.statusCode}) (Message: ${JSON.stringify(result)})`));
           } else {
               resolve(result);
           }
       } catch (e) {
           if (response.statusCode < 200 || response.statusCode > 299) {
-              reject(new Error(`Failed to POST ${path} (Status code: ${response.statusCode}) (Message: ${result})`));
+              reject(new Error(`Failed to ${verb} ${path} (Status code: ${response.statusCode}) (Message: ${result})`));
           } else {
               resolve(result);
           }

--- a/lib/request.js
+++ b/lib/request.js
@@ -14,16 +14,23 @@ module.exports = {
                     reject(new Error(`Failed to GET ${path} (Status code: ${response.statusCode})`));
                 }
 
-                let body = [];
-                response.on('data', chunk => body.push(chunk));
+                let result = [];
+                response.on('data', chunk => result.push(chunk));
                 response.on('end', _ => {
-                    body = body.join('');
+                    result = result.join('');
                     try {
-                        body = JSON.parse(body);
-                        resolve(body);
-                    }
-                    catch (e) {
-                        resolve(body);
+                        result = JSON.parse(result);
+                        if (response.statusCode < 200 || response.statusCode > 299) {
+                            reject(new Error(`Failed to POST ${path} (Status code: ${response.statusCode}) (Message: JSON.stringify(result))`));
+                        } else {
+                            resolve(result);
+                        }
+                    } catch (e) {
+                        if (response.statusCode < 200 || response.statusCode > 299) {
+                            reject(new Error(`Failed to POST ${path} (Status code: ${response.statusCode}) (Message: result)`));
+                        } else {
+                            resolve(result);
+                        }
                     }
                 });
             });
@@ -43,9 +50,6 @@ module.exports = {
             options.headers['Content-Length'] = Buffer.byteLength(body);
 
             request = http.request(options, response => {
-                if (response.statusCode < 200 || response.statusCode > 299) {
-                    reject(new Error(`Failed to POST ${path} (Status code: ${response.statusCode})`));
-                }
 
                 let result = [];
                 response.on('data', chunk => result.push(chunk));
@@ -53,10 +57,17 @@ module.exports = {
                     result = result.join('');
                     try {
                         result = JSON.parse(result);
-                        resolve(result);
-                    }
-                    catch (e) {
-                        resolve(result);
+                        if (response.statusCode < 200 || response.statusCode > 299) {
+                            reject(new Error(`Failed to POST ${path} (Status code: ${response.statusCode}) (Message: ${JSON.stringify(result)})`));
+                        } else {
+                            resolve(result);
+                        }
+                    } catch (e) {
+                        if (response.statusCode < 200 || response.statusCode > 299) {
+                            reject(new Error(`Failed to POST ${path} (Status code: ${response.statusCode}) (Message: result)`));
+                        } else {
+                            resolve(result);
+                        }
                     }
                 });
             });
@@ -87,10 +98,17 @@ module.exports = {
                     result = result.join('');
                     try {
                         result = JSON.parse(result);
-                        resolve(result);
-                    }
-                    catch (e) {
-                        resolve(result);
+                        if (response.statusCode < 200 || response.statusCode > 299) {
+                            reject(new Error(`Failed to POST ${path} (Status code: ${response.statusCode}) (Message: ${JSON.stringify(result)})`));
+                        } else {
+                            resolve(result);
+                        }
+                    } catch (e) {
+                        if (response.statusCode < 200 || response.statusCode > 299) {
+                            reject(new Error(`Failed to POST ${path} (Status code: ${response.statusCode}) (Message: ${result})`));
+                        } else {
+                            resolve(result);
+                        }
                     }
                 });
             });

--- a/lib/request.js
+++ b/lib/request.js
@@ -17,21 +17,7 @@ module.exports = {
                 let result = [];
                 response.on('data', chunk => result.push(chunk));
                 response.on('end', _ => {
-                    result = result.join('');
-                    try {
-                        result = JSON.parse(result);
-                        if (response.statusCode < 200 || response.statusCode > 299) {
-                            reject(new Error(`Failed to POST ${path} (Status code: ${response.statusCode}) (Message: JSON.stringify(result))`));
-                        } else {
-                            resolve(result);
-                        }
-                    } catch (e) {
-                        if (response.statusCode < 200 || response.statusCode > 299) {
-                            reject(new Error(`Failed to POST ${path} (Status code: ${response.statusCode}) (Message: result)`));
-                        } else {
-                            resolve(result);
-                        }
-                    }
+                    sendResponse(result, response, path, resolve, reject);
                 });
             });
             request.on('error', err => reject(err));
@@ -54,21 +40,7 @@ module.exports = {
                 let result = [];
                 response.on('data', chunk => result.push(chunk));
                 response.on('end', _ => {
-                    result = result.join('');
-                    try {
-                        result = JSON.parse(result);
-                        if (response.statusCode < 200 || response.statusCode > 299) {
-                            reject(new Error(`Failed to POST ${path} (Status code: ${response.statusCode}) (Message: ${JSON.stringify(result)})`));
-                        } else {
-                            resolve(result);
-                        }
-                    } catch (e) {
-                        if (response.statusCode < 200 || response.statusCode > 299) {
-                            reject(new Error(`Failed to POST ${path} (Status code: ${response.statusCode}) (Message: result)`));
-                        } else {
-                            resolve(result);
-                        }
-                    }
+                    sendResponse(result, response, path, resolve, reject);
                 });
             });
             request.on('error', err => reject(err));
@@ -95,25 +67,33 @@ module.exports = {
                 let result = [];
                 response.on('data', chunk => result.push(chunk));
                 response.on('end', _ => {
-                    result = result.join('');
-                    try {
-                        result = JSON.parse(result);
-                        if (response.statusCode < 200 || response.statusCode > 299) {
-                            reject(new Error(`Failed to POST ${path} (Status code: ${response.statusCode}) (Message: ${JSON.stringify(result)})`));
-                        } else {
-                            resolve(result);
-                        }
-                    } catch (e) {
-                        if (response.statusCode < 200 || response.statusCode > 299) {
-                            reject(new Error(`Failed to POST ${path} (Status code: ${response.statusCode}) (Message: ${result})`));
-                        } else {
-                            resolve(result);
-                        }
-                    }
+                    sendResponse(result, response, path, resolve, reject);
                 });
             });
             request.on('error', err => reject(err));
             request.end(body);
         });
     }
+}
+
+/**
+ sendResponse
+ commond function used by all methods to finalize a response.
+**/
+function sendResponse(result, response, path, resolve, reject) {
+      result = result.join('');
+      try {
+          result = JSON.parse(result);
+          if (response.statusCode < 200 || response.statusCode > 299) {
+              reject(new Error(`Failed to POST ${path} (Status code: ${response.statusCode}) (Message: ${JSON.stringify(result)})`));
+          } else {
+              resolve(result);
+          }
+      } catch (e) {
+          if (response.statusCode < 200 || response.statusCode > 299) {
+              reject(new Error(`Failed to POST ${path} (Status code: ${response.statusCode}) (Message: ${result})`));
+          } else {
+              resolve(result);
+          }
+      }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -383,7 +383,7 @@ describe('Check Image', () => {
 
               let body = res.body;
 
-              expect(body).to.deep.equal({code: 200, message: "Image Exists In Catalog: real-image vreal-version"});
+              expect(body).to.deep.equal({code: 200, message: "Image Exists In Catalog: real-image:real-version"});
 
               done();
           });

--- a/test/index.js
+++ b/test/index.js
@@ -89,7 +89,7 @@ describe('Deploy', function () {
 
                 expect(body).to.deep.equal({
                     code: 400,
-                    message: 'missing field name, missing field version'
+                    message: "missing field: 'name', missing field: 'version'"
                 });
 
                 done();
@@ -123,7 +123,21 @@ describe('Deploy', function () {
                 image: "registry.example.com/my-container:0.1.0",
                 version: "0.0.0"
             })
-            .expect(409, done);
+            .expect(409)
+            .end((err, res) => {
+                if (err) {
+                    return done(err);
+                }
+
+                let body = res.body;
+
+                expect(body).to.deep.equal({
+                    code: 409,
+                    message: `Failed to POST http://catalogit.test.services.dmtio.net/v1/containers (Status code: 409) (Message: {\"error\":\"Container Error: There is already a combination of my-container:0.0.0. Specify unique combinations.\"})`
+                });
+
+                done();
+            });
     });
 
     it('should fail with 422 when bad data is supplied', function (done) {
@@ -252,7 +266,7 @@ describe('Catalog', function () {
 
                 expect(body).to.deep.equal({
                     code: 400,
-                    message: 'missing field name, missing field version'
+                    message: "missing field: 'name', missing field: 'version'"
                 });
 
                 done();


### PR DESCRIPTION
* add some logging
* wait for the full buffer to come through, even on errors. this way we can get the error response in the body from the server, which choked. This helps in debugging things directly in the build logs, vs having to track down logs on the apis themselves. 