### PR TITLE
fix(bug): improve error handling when calls to shipit fail

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -24,16 +24,16 @@ dependencies:
       -d /data \
       -b "${CIRCLE_BRANCH}" \
       -n "${CIRCLE_BUILD_NUM}" > buildprops;
-    - source buildprops; docker build -t "quay.io/turner/${HARBOR_CONTAINER}:${HARBOR_VERSION}" .
-    - source buildprops; docker push "quay.io/turner/${HARBOR_CONTAINER}:${HARBOR_VERSION}"
+    - source buildprops; docker build -t "quay.io/turner/${CONTAINER}:${VERSION}" .
+    - source buildprops; docker push "quay.io/turner/${CONTAINER}:${VERSION}"
     - source buildprops; docker run quay.io/turner/harbor-deploy deploy \
-      -s "ops-${HARBOR_CONTAINER}" \
+      -s "ops-${CONTAINER}" \
       -r quay.io/turner \
-      -c "${HARBOR_CONTAINER}" \
-      -v "${HARBOR_VERSION}" \
+      -c "${CONTAINER}" \
+      -v "${VERSION}" \
       -e dev \
       -p ec2 \
-      -t "${SHIPMENT_BUILD_TOKEN}" \
+      -t "${TOKEN}" \
       -a https://customs.services.dmtio.net
 
 deployment:

--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,7 @@ dependencies:
       -v "${VERSION}" \
       -e dev \
       -p ec2 \
-      -t "${TOKEN}" \
+      -t "${SHIPMENT_BUILD_TOKEN}" \
       -a https://customs.services.dmtio.net
 
 deployment:

--- a/circle.yml
+++ b/circle.yml
@@ -21,20 +21,14 @@ dependencies:
     - docker info
     - docker login -e="${DOCKER_EMAIL}" -u="${DOCKER_USER}" -p="${DOCKER_PASSWORD}" quay.io
     - docker run -v $(pwd):/data quay.io/turner/harbor-deploy set_build_values \
-      -d /data \
-      -b "${CIRCLE_BRANCH}" \
-      -n "${CIRCLE_BUILD_NUM}" > buildprops;
-    - source buildprops; docker build -t "quay.io/turner/${CONTAINER}:${VERSION}" .
-    - source buildprops; docker push "quay.io/turner/${CONTAINER}:${VERSION}"
-    - source buildprops; docker run quay.io/turner/harbor-deploy deploy \
-      -s "ops-${CONTAINER}" \
-      -r quay.io/turner \
-      -c "${CONTAINER}" \
-      -v "${VERSION}" \
-      -e dev \
-      -p ec2 \
+      -s "ops-customs-api" \
       -t "${SHIPMENT_BUILD_TOKEN}" \
-      -a https://customs.services.dmtio.net
+      -e "dev" \
+      -b "${CIRCLE_BRANCH}" \
+      -n "${CIRCLE_BUILD_NUM}" > props;
+    - source props; docker build -t "${IMAGE}" .
+    - source props; docker push "${IMAGE}"
+    - source props; docker run -it --env-file props quay.io/turner/harbor-deploy catalog
 
 deployment:
   staging:

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -31,11 +31,17 @@ module.exports = {
                 }
             })
             .catch(reason => {
-                let code = helpers.parseStatusCode(reason);
+                let code = helpers.parseStatusCode(reason),
+                    message = reason.message || reason.toString();
 
-                debug('Request to ShipIt failed(%s): %s', reason.message || reason);
-                res.status(500);
-                res.json({code: 500, message: reason});
+                if (code === 404) {
+                    code = 400;
+                    message = `shipment ${req.params.shipment}:${req.params.environment} does not exist`
+                }
+
+                debug('Request to ShipIt failed(%s): %s', code, message);
+                res.status(code);
+                res.json({code: code, message: message});
             });
         } else {
             let err = `NoAuth: ${req.params.shipment}/${req.params.environment}/${req.params.provider} Payload: name: ${req.body.name}, ver: ${req.body.version}, img: ${req.body.image}}`

--- a/test/index.js
+++ b/test/index.js
@@ -42,6 +42,14 @@ describe('Deploy', function () {
             .get('/v1/shipment/my-shipment/environment/test-env')
             .replyWithFile(200, getMockData('shipit'));
 
+        nock(shipit)
+            .get('/v1/shipment/nonexistent/environment/dev')
+            .reply(404, {"code": 404, "message": "Shipment 'nonexistent' not found."});
+
+        nock(shipit)
+            .get('/v1/shipment/my-shipment/environment/nonexistent')
+            .reply(404, {"code": 404, "message": "Environment 'nonexistent' not found for Shipment 'my-shipment'."});
+
         nock(catalogit)
             .post('/v1/containers', {
                 catalog: true,
@@ -152,6 +160,46 @@ describe('Deploy', function () {
             });
     });
 
+    it('should fail with a 400 when trying to deploy to a nonexistent Shipment', function (done) {
+        request(server)
+            .post('/deploy/nonexistent/dev/provider')
+            .set('x-build-token', testAuthToken)
+            .send(data)
+            .expect(400)
+            .end((err, res) => {
+                if (err) {
+                    return done(err);
+                }
+
+                let body = res.body;
+
+                expect(body.code).to.equal(400);
+                expect(body.message).to.equal('shipment nonexistent:dev does not exist');
+
+                done();
+            });
+    });
+
+    it('should fail with a 400 when trying to deploy to a nonexistent Environment', function (done) {
+        request(server)
+            .post('/deploy/my-shipment/nonexistent/provider')
+            .set('x-build-token', testAuthToken)
+            .send(data)
+            .expect(400)
+            .end((err, res) => {
+                if (err) {
+                    return done(err);
+                }
+
+                let body = res.body;
+
+                expect(body.code).to.equal(400);
+                expect(body.message).to.equal('shipment my-shipment:nonexistent does not exist');
+
+                done();
+            });
+    });
+
     it('should succeed', function (done) {
         request(server)
             .post(path)
@@ -224,6 +272,14 @@ describe('Catalog', function () {
             .get('/v1/shipment/my-shipment/environment/test-env')
             .replyWithFile(200, getMockData('shipit'));
 
+        nock(shipit)
+            .get('/v1/shipment/nonexistent/environment/dev')
+            .reply(404, {"code": 404, "message": "Shipment 'nonexistent' not found."});
+
+        nock(shipit)
+            .get('/v1/shipment/my-shipment/environment/nonexistent')
+            .reply(404, {"code": 404, "message": "Environment 'nonexistent' not found for Shipment 'my-shipment'."});
+
         nock(catalogit)
             .post('/v1/containers', {
                 name: "my-container",
@@ -287,6 +343,46 @@ describe('Catalog', function () {
                 version: "0.0.0"
             })
             .expect(409, done);
+    });
+
+    it('should fail with a 400 when trying to catalog to a nonexistent Shipment', function (done) {
+        request(server)
+            .post('/catalog/nonexistent/dev/provider')
+            .set('x-build-token', testAuthToken)
+            .send(data)
+            .expect(400)
+            .end((err, res) => {
+                if (err) {
+                    return done(err);
+                }
+
+                let body = res.body;
+
+                expect(body.code).to.equal(400);
+                expect(body.message).to.equal('shipment nonexistent:dev does not exist');
+
+                done();
+            });
+    });
+
+    it('should fail with a 400 when trying to catalog to a nonexistent Environment', function (done) {
+        request(server)
+            .post('/catalog/my-shipment/nonexistent/provider')
+            .set('x-build-token', testAuthToken)
+            .send(data)
+            .expect(400)
+            .end((err, res) => {
+                if (err) {
+                    return done(err);
+                }
+
+                let body = res.body;
+
+                expect(body.code).to.equal(400);
+                expect(body.message).to.equal('shipment my-shipment:nonexistent does not exist');
+
+                done();
+            });
     });
 
     it('should succeed', function (done) {


### PR DESCRIPTION
Fixes issue #32, where calls that failed with a 404 to ShipIt returned a 500 with no message.